### PR TITLE
Fix for Android Lollipop

### DIFF
--- a/src/com/germainz/dynamicalarmicon/ClockDrawable.java
+++ b/src/com/germainz/dynamicalarmicon/ClockDrawable.java
@@ -33,7 +33,7 @@ public class ClockDrawable extends Drawable {
 
 		/* Clock's circle outline and middle dot */
         mPaint.setStyle(Paint.Style.STROKE);
-        mPaint.setStrokeWidth(radius / 7f);
+        mPaint.setStrokeWidth(radius / (XposedMod.IS_LOLLIPOP_OR_ABOVE ? 5f : 7f));
         canvas.drawCircle(x, y, radius, mPaint);
         canvas.drawCircle(x, y, radius / 20f, mPaint);
 


### PR DESCRIPTION
This should be tested on pre Lollipop devices as well.

- the cst'r interface of NotificationData.Entry has removed IBinder in Lollipop
- the spot of the alarm time is not idx=1 anymore, therefore search all strings for a matching alarm time string
- ContentObserver for NEXT_ALARM_FORMATTED has been depreciated and is not triggered anymore, therefore use the new BroadcastReceiver for ACTION_NEXT_ALARM_CLOCK_CHANGED
- it seems like in Android Lollipop the size of the drawable has to be adjusted manually, otherwise the width would be only 1-2px
- added hook for StatusBarHeaderView which also indicates the alarm next to the time and date when the quick settings panel is fully expanded